### PR TITLE
feat: Hosted UI — login, register, forgot/reset password

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,24 @@
 
 Ironiauth es un Identity Provider (IdP) multi-tenant centralizado construido en Elixir/Phoenix. Permite que múltiples aplicaciones cliente (App A, App B, etc.) deleguen autenticación y autorización a un único servicio.
 
+Ironiauth tiene **dos modos de integración**:
+
+| Modo | Quién sirve la UI | Cómo funciona |
+|------|-------------------|---------------|
+| **API-only** | La app cliente | Backend llama directamente a `/api/v1/sign_in`, `/api/v1/sign_up` con `api_key` |
+| **Hosted UI** | Ironiauth | La app redirige el browser a `/login?company_uuid=...&redirect_uri=...` |
+
+## Convenciones de lenguaje
+
+- **Código, comentarios, CLAUDE.md**: español
+- **Templates HTML (Hosted UI)**: inglés — los formularios, mensajes de error y botones van en inglés ya que pueden ser usados por usuarios de cualquier app cliente
+
 ## Arquitectura del modelo de datos
 
 ```
 Company (aplicación cliente)
   ├── api_key          → autentica llamadas desde el backend de cada app
-  ├── uuid             → identifica la company en el JWT
+  ├── uuid             → identifica la company en el JWT y en la Hosted UI
   ├── has_many :permissions
   ├── has_many :groups
   └── has_many :memberships
@@ -33,14 +45,34 @@ GroupPermission  → join Group ↔ Permission
 UserGroup        → join User ↔ Group
 ```
 
-## Flujo de integración con una app cliente
+## Flujo de integración — Hosted UI (recomendado)
 
-1. La app cliente (ej. open_car Rails) tiene `IRONIAUTH_API_KEY` en su `.env`
-2. El backend de la app llama a `/api/v1/sign_up` o `/api/v1/sign_in` con `Authorization: Bearer <api_key>`
-3. Ironiauth retorna un JWT firmado con **RS256** (asimétrico RSA)
-4. El JWT incluye solo identidad: `company_uuid`, `user_uuid`
-5. La app valida el JWT localmente con la **clave pública RSA** obtenida de `/.well-known/jwks.json`
-6. Los permisos se consultan vía `GET /api/v1/users/permissions` y se cachean en sesión (5 min)
+```
+App cliente (Rails)                    Ironiauth                       Browser
+      │                                     │                              │
+      │  redirect_to hosted_login_url ──────►│                              │
+      │  /login?company_uuid=<uuid>         │◄── GET /login ───────────────│
+      │  &redirect_uri=<callback_url>       │──► render login form ────────►│
+      │                                     │◄── POST /login (email+pass) ──│
+      │                                     │──► redirect redirect_uri?jwt= ►│
+      │◄── GET /auth/callback?jwt=<token> ──│                              │
+      │  (guarda jwt en sesión)             │                              │
+      │  window.location.replace('/')       │                              │
+```
+
+1. La app cliente construye la URL de Ironiauth en el backend: `hosted_login_url(callback_url:)` en `IroniauthClient`
+2. El browser va a `/login?company_uuid=<uuid>&redirect_uri=<callback_url>` en Ironiauth
+3. Ironiauth muestra el formulario de login (o register, forgot-password)
+4. Al autenticar, Ironiauth redirige a `redirect_uri?jwt=<token>`
+5. La app recibe el JWT en `/auth/callback`, lo guarda en sesión y limpia la URL con `window.location.replace('/')`
+
+## Flujo de integración — API-only (modo headless)
+
+1. La app cliente tiene `IRONIAUTH_API_KEY` en su `.env` del backend
+2. El backend llama a `/api/v1/sign_in` con `Authorization: Bearer <api_key>`
+3. Ironiauth retorna un JWT firmado con **RS256**
+4. La app valida el JWT localmente con la clave pública de `/.well-known/jwks.json`
+5. Los permisos se consultan vía `GET /api/v1/users/permissions` y se cachean en sesión (5 min)
 
 ## JWT Claims
 
@@ -57,6 +89,23 @@ El JWT usa RS256 y contiene solo identidad — sin permisos embebidos:
 ```
 
 Los permisos se obtienen frescos vía `GET /api/v1/users/permissions` (autenticado con JWT). Esto permite que los cambios de grupos se reflejen inmediatamente sin esperar que expire el token.
+
+## Hosted UI — rutas del browser
+
+```
+GET  /login               → formulario de login
+POST /login               → procesa login, redirige con JWT
+GET  /register            → formulario de registro
+POST /register            → crea usuario, redirige con JWT
+GET  /forgot-password     → formulario de forgot password
+POST /forgot-password     → envía email de reset
+GET  /reset-password      → formulario de nueva contraseña (token en query param)
+POST /reset-password      → procesa reset, redirige a /login
+```
+
+Todos reciben `company_uuid` y `redirect_uri` como query params (GET) o hidden fields (POST). El `company_uuid` es construido por el backend de la app cliente — nunca lo ingresa el usuario.
+
+Después del reset de contraseña, el browser es redirigido a `/login?company_uuid=<uuid>&redirect_uri=<url>` en Ironiauth — nunca directamente a la app externa, eliminando el riesgo de open redirect.
 
 ## Endpoint JWKS
 
@@ -77,11 +126,12 @@ Los permisos se obtienen frescos vía `GET /api/v1/users/permissions` (autentica
 
 ## Pipelines de autenticación en el router
 
-- **Sin auth (solo `:api`)**: `GET /`, `GET /.well-known/jwks.json`, `reset_password` — el token del email identifica al user sin necesidad de contexto de company
-- **api_key_authenticated**: `sign_up`, `sign_in`, `forgot_password` — el backend de la app envía `Authorization: Bearer <api_key>`. `forgot_password` necesita api_key para saber a qué company pertenece el email (Model B: mismo email puede existir en varias companies)
-- **jwt_authenticated**: todos los demás endpoints — `Authorization: Bearer <jwt>`
+- **`:browser`**: Hosted UI — login, register, forgot-password, reset-password. Incluye `put_root_layout`, CSRF, session.
+- **Sin auth (`:api`)**: `GET /`, `GET /.well-known/jwks.json` — públicos
+- **`api_key_authenticated`**: `sign_up`, `sign_in`, `forgot_password` (API-only) — el backend de la app envía `Authorization: Bearer <api_key>`
+- **`jwt_authenticated`**: todos los demás endpoints — `Authorization: Bearer <jwt>`
 
-Cualquier ruta no definida devuelve `{"error": "Not found"}` con status 404 (catch-all al final del router).
+Cualquier ruta no definida devuelve `{"error": "Not found"}` con status 404 (catch-all al final del router). Las rutas de dev (`/dev/mailbox`, `/dev/dashboard`) van ANTES del catch-all.
 
 ## Variables de entorno requeridas
 
@@ -91,7 +141,15 @@ DATABASE_URL=               # solo en producción
 SECRET_KEY_BASE=            # solo en producción (mix phx.gen.secret)
 ```
 
-En dev/test la clave se lee de `priv/keys/private.pem` (gitignoreada). Generarla con:
+### Variables que necesita la app cliente (ej. open_car)
+
+```bash
+IRONIAUTH_API_KEY=          # api_key de la company en Ironiauth
+IRONIAUTH_COMPANY_UUID=     # uuid de la company (para construir hosted_login_url)
+IRONIAUTH_BASE_URL=         # ej: http://localhost:4000
+```
+
+En dev/test la clave RSA se lee de `priv/keys/private.pem` (gitignoreada). Generarla con:
 ```bash
 openssl genrsa 2048 > priv/keys/private.pem
 ```
@@ -117,8 +175,9 @@ Los seeds crean:
 ## Decisiones de diseño importantes
 
 - **RS256 en lugar de HS512** — firma asimétrica: Ironiauth firma con la clave privada (que solo conoce), las apps verifican con la clave pública del endpoint JWKS. Una app comprometida no puede forjar JWTs para otras companies.
-- **Model B — email único por company, no global** — el mismo email puede existir en distintas companies como usuarios completamente independientes. Un atacante que obtenga credenciales de open_car no puede usarlas en todo_app. `sign_in` y `forgot_password` siempre resuelven el usuario escopado a la company del api_key.
-- **company_uuid nunca viaja desde el browser** — viene del `api_key` que identifica la company en el backend
+- **Model B — email único por company, no global** — el mismo email puede existir en distintas companies como usuarios completamente independientes. `sign_in` y `forgot_password` siempre resuelven el usuario escopado a la company del api_key (modo API) o del company_uuid en la query param (Hosted UI).
+- **company_uuid en Hosted UI** — viaja como query param en la URL que construye el backend de la app cliente. El usuario lo ve en la barra de dirección pero no puede cambiarlo por uno diferente porque Ironiauth verifica que exista en la DB. No es un secreto — es un identificador público.
+- **Sin open redirect en reset password** — después de resetear la contraseña, el redirect va a `/login?company_uuid=...` dentro de Ironiauth, no directamente a la app externa. Esto evita que un atacante forje links de reset con `redirect_uri` malicioso.
 - **Permisos fuera del JWT** — el JWT solo lleva identidad. Los permisos se consultan vía `GET /users/permissions` y se cachean en el cliente (ej. 5 min en sesión de Rails). Cambios de grupo son inmediatamente visibles sin esperar expiración del JWT.
 - **Grupos** — un usuario puede pertenecer a N grupos, cada grupo tiene N permisos. Resuelve el problema de eficiencia con muchos usuarios
 - **admin?/1 y superadmin?/1 son fail-closed** — retornan `false` en cualquier error, nunca permiten acceso por defecto
@@ -127,11 +186,13 @@ Los seeds crean:
   - `admin` → dueño de una company. Gestiona grupos, permisos y usuarios dentro de su company. Plug: `IsAdmin`.
   - `user` → usuario final. Solo puede ver/editar su propio perfil y consultar sus propios permisos.
 - **Memberships** — reemplaza la relación directa `user.company_id` para soportar usuarios en múltiples companies
+- **active: true forzado** — `create_user_for_company/2` siempre crea usuarios con `active: true`. Los usuarios inactivos no pueden autenticarse.
 
 ## Dependencias clave
 
 - `guardian ~> 2.0` — JWT con RS256. Requiere clave RSA en formato JWK mapa (via JOSE).
 - `guardian_db ~> 3.0` — revocación de tokens en DB. El sweeper se llama `Guardian.DB.Sweeper` (en versiones anteriores era `Guardian.DB.Token.SweeperServer`). Está registrado en `IroniauthWeb.Telemetry`.
+- `swoosh` — mailer. En dev usa `Adapters.Local` y el mailbox está en `/dev/mailbox`. El forgot_password email se envía con `Task.Supervisor` (asíncrono).
 
 ## Patrones de código
 
@@ -139,3 +200,4 @@ Los seeds crean:
 - Los controllers no acceden a `Repo` directamente
 - `conn.assigns.current_company` es cargado por el plug `CurrentUser` — los controllers no lo resuelven por su cuenta
 - Formato de permisos: `"recurso#accion"` (mismo separador `#` que el sistema Rails de referencia)
+- `AuthController` maneja toda la Hosted UI. `SessionsController` y `PasswordsController` manejan la API-only.

--- a/docs/integrations/rails.md
+++ b/docs/integrations/rails.md
@@ -174,7 +174,9 @@ end
 <% end %>
 ```
 
-## Registro e inicio de sesión
+## Opción A — Flujo API (login desde tu propia UI)
+
+El backend de Rails llama directamente a Ironiauth con el api_key.
 
 ```ruby
 # SessionsController
@@ -196,3 +198,116 @@ def destroy
   redirect_to login_path
 end
 ```
+
+---
+
+## Opción B — Hosted UI (login delegado a Ironiauth)
+
+Ironiauth sirve las páginas de login, registro y recuperación de contraseña. Rails redirige al usuario a Ironiauth, el usuario se autentica, e Ironiauth devuelve el browser a Rails con un JWT en la query string.
+
+### Variables de entorno adicionales
+
+```bash
+IRONIAUTH_COMPANY_UUID=<uuid público de tu company>  # visible en el JWT, no es secreto
+IRONIAUTH_CALLBACK_URL=https://tu-rails-app.com/auth/callback
+```
+
+> `IRONIAUTH_COMPANY_UUID` es el `uuid` de tu Company en Ironiauth (campo público,
+> aparece en el JWT). Distinto de `IRONIAUTH_API_KEY` que es el secreto del backend.
+
+### Rutas
+
+```ruby
+# config/routes.rb
+get  "/auth/callback", to: "sessions#callback"
+get  "/auth/login",    to: "sessions#redirect_to_ironiauth"
+delete "/logout",      to: "sessions#destroy"
+```
+
+### SessionsController — acciones Hosted UI
+
+```ruby
+IRONIAUTH_URL          = ENV.fetch("IRONIAUTH_URL")
+IRONIAUTH_COMPANY_UUID = ENV.fetch("IRONIAUTH_COMPANY_UUID")
+IRONIAUTH_CALLBACK_URL = ENV.fetch("IRONIAUTH_CALLBACK_URL")
+
+# GET /auth/login  →  redirige al Hosted UI de Ironiauth
+def redirect_to_ironiauth
+  params = {
+    company_uuid: IRONIAUTH_COMPANY_UUID,
+    redirect_uri: IRONIAUTH_CALLBACK_URL
+  }
+  redirect_to "#{IRONIAUTH_URL}/login?#{params.to_query}", allow_other_host: true
+end
+
+# GET /auth/callback?jwt=<token>  →  captura el JWT y crea sesión
+#
+# Usamos window.location.replace en vez de redirect_to para que la URL
+# con ?jwt= NUNCA quede en el historial del browser.
+def callback
+  jwt = params[:jwt]
+
+  if jwt.blank?
+    redirect_to auth_login_path, alert: "Autenticación fallida"
+    return
+  end
+
+  session[:ironiauth_token] = jwt
+  session.delete(:ironiauth_permissions)
+  session.delete(:permissions_cached_at)
+
+  # Renderizar una página mínima que usa location.replace para
+  # eliminar la URL del historial antes de redirigir a root.
+  render html: <<~HTML.html_safe, layout: false
+    <!DOCTYPE html><html><head>
+    <script>window.location.replace('/');</script>
+    </head><body>Redirigiendo...</body></html>
+  HTML
+end
+
+# DELETE /logout
+def destroy
+  session.delete(:ironiauth_token)
+  session.delete(:ironiauth_permissions)
+  session.delete(:permissions_cached_at)
+  redirect_to auth_login_path
+end
+```
+
+### Flujo completo
+
+```
+Browser                    Rails                      Ironiauth
+  │                          │                            │
+  │  GET /auth/login         │                            │
+  │─────────────────────────>│                            │
+  │                          │  redirect 302              │
+  │<─────────────────────────│  Location: /login?...      │
+  │                                                       │
+  │  GET /login?company_uuid=X&redirect_uri=Y             │
+  │──────────────────────────────────────────────────────>│
+  │                                                       │  muestra form
+  │<──────────────────────────────────────────────────────│
+  │  POST /login (email + password)                       │
+  │──────────────────────────────────────────────────────>│
+  │                                                       │  autentica
+  │  redirect 302                                         │
+  │<──────────────────────────────────────────────────────│
+  │  Location: <redirect_uri>?jwt=<token>                 │
+  │                          │                            │
+  │  GET /auth/callback?jwt=X│                            │
+  │─────────────────────────>│                            │
+  │                          │  session[:ironiauth_token] │
+  │  redirect → /            │                            │
+  │<─────────────────────────│                            │
+```
+
+### Seguridad del redirect
+
+El JWT viaja en la query string, que puede quedar en logs del servidor y en el
+`Referer` header. Mitigaciones recomendadas:
+
+1. **Eliminar el param de la URL inmediatamente** — en el callback, tras guardar
+   en sesión hacer `redirect_to root_path` (sin el jwt en la URL).
+2. El `redirect_uri` debe ser `https` en producción.
+3. Los JWTs tienen TTL corto (10 min para usuarios normales).

--- a/lib/ironiauth/accounts.ex
+++ b/lib/ironiauth/accounts.ex
@@ -141,6 +141,7 @@ defmodule Ironiauth.Accounts do
     if email_taken_in_company?(email, company.id) do
       {:error, :email_taken_in_company}
     else
+      attrs = Map.merge(%{"active" => true}, stringify_keys(attrs))
       Repo.transaction(fn ->
         with {:ok, user} <- create_user(attrs),
              {:ok, _}    <- create_membership(%{user_id: user.id, company_id: company.id}) do
@@ -150,6 +151,10 @@ defmodule Ironiauth.Accounts do
         end
       end)
     end
+  end
+
+  defp stringify_keys(attrs) when is_map(attrs) do
+    Map.new(attrs, fn {k, v} -> {to_string(k), v} end)
   end
 
   defp email_taken_in_company?(email, company_id) do

--- a/lib/ironiauth/accounts/user.ex
+++ b/lib/ironiauth/accounts/user.ex
@@ -23,7 +23,7 @@ defmodule Ironiauth.Accounts.User do
   end
 
   @required_fields_create ~w(username email password password_confirmation)a
-  @cast_fields ~w(username email password password_confirmation active)a
+  @cast_fields ~w(username email password password_confirmation active uuid)a
   @update_fields ~w(active username password_reset_token password_reset_sent_at)a
   @reset_password_fields ~w(password password_confirmation password_reset_token password_reset_sent_at)a
 
@@ -37,6 +37,7 @@ defmodule Ironiauth.Accounts.User do
     |> unique_constraint(:username)
     |> validate_confirmation(:password, on: [:create])
     |> put_password_hash
+    |> put_uuid()
   end
 
   def update_changeset(user, attrs \\ %{}) do
@@ -53,6 +54,11 @@ defmodule Ironiauth.Accounts.User do
     |> put_password_hash
   end
 
+
+  defp put_uuid(%Ecto.Changeset{data: %{uuid: nil}} = changeset) do
+    put_change(changeset, :uuid, Ecto.UUID.generate())
+  end
+  defp put_uuid(changeset), do: changeset
 
   defp put_password_hash(changeset) do
     case changeset do

--- a/lib/ironiauth/mailers/reset_password_mailer.ex
+++ b/lib/ironiauth/mailers/reset_password_mailer.ex
@@ -1,14 +1,35 @@
 defmodule Ironiauth.Mailers.ResetPasswordMailer do
   import Swoosh.Email
 
-  def password_reset(user) do
+  def password_reset(user, company_uuid \\ "", redirect_uri \\ "") do
+    base_url = Application.get_env(:ironiauth, :base_url, IroniauthWeb.Endpoint.url())
+    params = URI.encode_query(%{
+      "token"        => user.password_reset_token,
+      "company_uuid" => company_uuid,
+      "redirect_uri" => redirect_uri
+    })
+    reset_link = "#{base_url}/reset-password?#{params}"
+
     new()
     |> to({user.username, user.email})
-    |> from({"No reply", "no-reply@domain.com"})
-    |> subject("Wellcome, #{user.username}!")
-    |> html_body("
-    <h1>Hello #{user.username}</h1>
-    </br>
-    <p>Hello #{user.username} your reset password link <a href='localhost:5000/frontend_url/reset_password?token=#{user.password_reset_token}'/>is here</p>")
+    |> from({"Ironiauth", "no-reply@ironiauth.com"})
+    |> subject("Reset your password")
+    |> html_body("""
+    <h2>Reset your password</h2>
+    <p>Hi #{user.username},</p>
+    <p>Click the link below to reset your password. This link expires in 2 hours.</p>
+    <p><a href="#{reset_link}">Reset password</a></p>
+    <p>If you didn't request this, you can ignore this email.</p>
+    """)
+    |> text_body("""
+    Reset your password
+
+    Hi #{user.username},
+
+    Click the link below to reset your password (expires in 2 hours):
+    #{reset_link}
+
+    If you didn't request this, ignore this email.
+    """)
   end
 end

--- a/lib/ironiauth/services/user/forgot_password_service.ex
+++ b/lib/ironiauth/services/user/forgot_password_service.ex
@@ -1,7 +1,7 @@
 defmodule Ironiauth.Services.User.ForgotPasswordService do
   alias Ironiauth.Accounts
 
-  def call(email, company) do
+  def call(email, company, redirect_uri \\ "") do
     case Accounts.get_by_email_active_in_company(email, company.id) do
       nil ->
         {:ok, :send_passwd_mailer}
@@ -11,7 +11,7 @@ defmodule Ironiauth.Services.User.ForgotPasswordService do
 
         Task.Supervisor.start_child(Ironiauth.AsyncEmailSupervisor, fn ->
           updated_user
-          |> Ironiauth.Mailers.ResetPasswordMailer.password_reset()
+          |> Ironiauth.Mailers.ResetPasswordMailer.password_reset(company.uuid, redirect_uri)
           |> Ironiauth.Mailer.deliver()
         end)
 

--- a/lib/ironiauth_web.ex
+++ b/lib/ironiauth_web.ex
@@ -19,6 +19,15 @@ defmodule IroniauthWeb do
 
   def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
 
+  def html do
+    quote do
+      use Phoenix.Component
+      import Phoenix.HTML
+      import IroniauthWeb.Gettext
+      unquote(verified_routes())
+    end
+  end
+
   def router do
     quote do
       use Phoenix.Router, helpers: false

--- a/lib/ironiauth_web/components/layouts.ex
+++ b/lib/ironiauth_web/components/layouts.ex
@@ -1,0 +1,5 @@
+defmodule IroniauthWeb.Layouts do
+  use IroniauthWeb, :html
+
+  embed_templates "layouts/*"
+end

--- a/lib/ironiauth_web/components/layouts/app.html.heex
+++ b/lib/ironiauth_web/components/layouts/app.html.heex
@@ -1,0 +1,1 @@
+<%= @inner_content %>

--- a/lib/ironiauth_web/components/layouts/root.html.heex
+++ b/lib/ironiauth_web/components/layouts/root.html.heex
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()}/>
+    <title>Ironiauth</title>
+    <style>
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background: #f0f2f5;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #1a1a2e;
+      }
+      .card {
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 4px 24px rgba(0,0,0,.08);
+        padding: 2.5rem 2rem;
+        width: 100%;
+        max-width: 400px;
+      }
+      .logo {
+        text-align: center;
+        margin-bottom: 1.75rem;
+      }
+      .logo h1 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: #4f46e5;
+        letter-spacing: -.5px;
+      }
+      .logo p {
+        font-size: .85rem;
+        color: #6b7280;
+        margin-top: .25rem;
+      }
+      .field { margin-bottom: 1rem; }
+      label {
+        display: block;
+        font-size: .85rem;
+        font-weight: 500;
+        color: #374151;
+        margin-bottom: .35rem;
+      }
+      input[type=email], input[type=password], input[type=text] {
+        width: 100%;
+        padding: .6rem .85rem;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        font-size: .95rem;
+        outline: none;
+        transition: border-color .15s;
+      }
+      input:focus { border-color: #4f46e5; box-shadow: 0 0 0 3px rgba(79,70,229,.1); }
+      .btn {
+        display: block;
+        width: 100%;
+        padding: .7rem 1rem;
+        background: #4f46e5;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        font-size: .95rem;
+        font-weight: 600;
+        cursor: pointer;
+        margin-top: 1.25rem;
+        transition: background .15s;
+      }
+      .btn:hover { background: #4338ca; }
+      .alert-error {
+        background: #fee2e2;
+        border: 1px solid #fca5a5;
+        border-radius: 8px;
+        color: #b91c1c;
+        font-size: .875rem;
+        padding: .75rem 1rem;
+        margin-bottom: 1.25rem;
+      }
+      .alert-success {
+        background: #d1fae5;
+        border: 1px solid #6ee7b7;
+        border-radius: 8px;
+        color: #065f46;
+        font-size: .875rem;
+        padding: .75rem 1rem;
+        margin-bottom: 1.25rem;
+      }
+      .links {
+        text-align: center;
+        margin-top: 1.25rem;
+        font-size: .85rem;
+        color: #6b7280;
+      }
+      .links a { color: #4f46e5; text-decoration: none; font-weight: 500; }
+      .links a:hover { text-decoration: underline; }
+      .divider { margin: 0 .4rem; }
+    </style>
+  </head>
+  <body>
+    <%= @inner_content %>
+  </body>
+</html>

--- a/lib/ironiauth_web/controllers/auth_controller.ex
+++ b/lib/ironiauth_web/controllers/auth_controller.ex
@@ -1,0 +1,182 @@
+defmodule IroniauthWeb.AuthController do
+  use IroniauthWeb, :controller
+
+  alias Ironiauth.{Accounts, Management, Guardian}
+  alias Ironiauth.Services.User.ForgotPasswordService
+
+  # GET /login?company_uuid=<uuid>&redirect_uri=<url>
+  def login(conn, %{"company_uuid" => company_uuid, "redirect_uri" => redirect_uri}) do
+    case Management.get_company_by_uuid(company_uuid) do
+      {:ok, company} ->
+        render(conn, :login,
+          company: company,
+          redirect_uri: redirect_uri,
+          email: "",
+          error: nil
+        )
+
+      {:error, _} ->
+        conn |> put_status(:not_found) |> json(%{error: "Company not found"})
+    end
+  end
+
+  def login(conn, _), do: conn |> put_status(:bad_request) |> json(%{error: "Missing company_uuid or redirect_uri"})
+
+  # POST /login
+  def do_login(conn, %{"company_uuid" => company_uuid, "redirect_uri" => redirect_uri, "email" => email, "password" => password}) do
+    case Accounts.token_sign_in(email, password, company_uuid) do
+      {:ok, token, _claims} ->
+        redirect(conn, external: append_jwt(redirect_uri, token))
+
+      _ ->
+        {:ok, company} = Management.get_company_by_uuid(company_uuid)
+        render(conn, :login,
+          company: company,
+          redirect_uri: redirect_uri,
+          email: email,
+          error: "Invalid email or password"
+        )
+    end
+  end
+
+  # GET /register?company_uuid=<uuid>&redirect_uri=<url>
+  def register(conn, %{"company_uuid" => company_uuid, "redirect_uri" => redirect_uri}) do
+    case Management.get_company_by_uuid(company_uuid) do
+      {:ok, company} ->
+        render(conn, :register,
+          company: company,
+          redirect_uri: redirect_uri,
+          username: "",
+          email: "",
+          error: nil
+        )
+
+      {:error, _} ->
+        conn |> put_status(:not_found) |> json(%{error: "Company not found"})
+    end
+  end
+
+  def register(conn, _), do: conn |> put_status(:bad_request) |> json(%{error: "Missing company_uuid or redirect_uri"})
+
+  # POST /register
+  def do_register(conn, %{"company_uuid" => company_uuid, "redirect_uri" => redirect_uri, "user" => user_params}) do
+    with {:ok, company} <- Management.get_company_by_uuid(company_uuid),
+         {:ok, user}    <- Accounts.create_user_for_company(user_params, company),
+         {:ok, _}       <- Accounts.create_user_role(%{user_id: user.id, role_name: :user}),
+         {:ok, token, _} <- Guardian.create_token(user, %{company_uuid: company.uuid, user_uuid: user.uuid}) do
+      redirect(conn, external: append_jwt(redirect_uri, token))
+    else
+      {:error, :email_taken_in_company} ->
+        {:ok, company} = Management.get_company_by_uuid(company_uuid)
+        render(conn, :register,
+          company: company,
+          redirect_uri: redirect_uri,
+          username: user_params["username"] || "",
+          email: user_params["email"] || "",
+          error: "Email has already been taken"
+        )
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:ok, company} = Management.get_company_by_uuid(company_uuid)
+        render(conn, :register,
+          company: company,
+          redirect_uri: redirect_uri,
+          username: user_params["username"] || "",
+          email: user_params["email"] || "",
+          error: changeset_error_message(changeset)
+        )
+
+      _ ->
+        {:ok, company} = Management.get_company_by_uuid(company_uuid)
+        render(conn, :register,
+          company: company,
+          redirect_uri: redirect_uri,
+          username: user_params["username"] || "",
+          email: user_params["email"] || "",
+          error: "Registration failed. Please try again."
+        )
+    end
+  end
+
+  # GET /forgot-password?company_uuid=<uuid>&redirect_uri=<url>
+  def forgot_password(conn, %{"company_uuid" => company_uuid, "redirect_uri" => redirect_uri}) do
+    case Management.get_company_by_uuid(company_uuid) do
+      {:ok, company} ->
+        render(conn, :forgot_password, company: company, redirect_uri: redirect_uri, sent: false)
+
+      {:error, _} ->
+        conn |> put_status(:not_found) |> json(%{error: "Company not found"})
+    end
+  end
+
+  def forgot_password(conn, _), do: conn |> put_status(:bad_request) |> json(%{error: "Missing company_uuid"})
+
+  # POST /forgot-password
+  def do_forgot_password(conn, %{"company_uuid" => company_uuid, "redirect_uri" => redirect_uri, "email" => email}) do
+    case Management.get_company_by_uuid(company_uuid) do
+      {:ok, company} ->
+        ForgotPasswordService.call(email, company, redirect_uri)
+        render(conn, :forgot_password, company: company, redirect_uri: redirect_uri, sent: true)
+
+      {:error, _} ->
+        conn |> put_status(:not_found) |> json(%{error: "Company not found"})
+    end
+  end
+
+  # GET /reset-password?token=<token>&company_uuid=<uuid>&redirect_uri=<url>
+  def reset_password_form(conn, %{"token" => token} = params) do
+    company_uuid = Map.get(params, "company_uuid", "")
+    redirect_uri = Map.get(params, "redirect_uri", "")
+    render(conn, :reset_password, token: token, company_uuid: company_uuid, redirect_uri: redirect_uri, error: nil)
+  end
+
+  def reset_password_form(conn, _) do
+    conn |> put_status(:bad_request) |> json(%{error: "Missing token"})
+  end
+
+  # POST /reset-password
+  def do_reset_password(conn, %{"token" => token, "company_uuid" => company_uuid, "redirect_uri" => redirect_uri, "user" => pass_attrs}) do
+    service = Ironiauth.Services.User.ResetPasswordService.new(token, pass_attrs)
+
+    case Ironiauth.Services.User.ResetPasswordService.call(service) do
+      {:ok, _user} ->
+        login_url = build_login_url(company_uuid, redirect_uri)
+        render(conn, :reset_password_success, login_url: login_url)
+
+      {:error, :reset_token_expired} ->
+        render(conn, :reset_password, token: token, company_uuid: company_uuid, redirect_uri: redirect_uri, error: "This reset link has expired. Please request a new one.")
+
+      {:error, :user_not_found} ->
+        render(conn, :reset_password, token: token, company_uuid: company_uuid, redirect_uri: redirect_uri, error: "Invalid reset link.")
+
+      {:error, :password_reset_failed} ->
+        render(conn, :reset_password, token: token, company_uuid: company_uuid, redirect_uri: redirect_uri, error: "Could not reset password. Please check your input and try again.")
+    end
+  end
+
+  def do_reset_password(conn, %{"token" => token, "user" => pass_attrs}) do
+    do_reset_password(conn, %{"token" => token, "company_uuid" => "", "redirect_uri" => "", "user" => pass_attrs})
+  end
+
+  defp build_login_url("", _redirect_uri), do: "/login"
+  defp build_login_url(company_uuid, redirect_uri) do
+    "/login?" <> URI.encode_query(%{"company_uuid" => company_uuid, "redirect_uri" => redirect_uri})
+  end
+
+
+  defp append_jwt(redirect_uri, token) do
+    uri = URI.parse(redirect_uri)
+    existing = URI.decode_query(uri.query || "")
+    query = URI.encode_query(Map.put(existing, "jwt", token))
+    URI.to_string(%{uri | query: query})
+  end
+
+  defp changeset_error_message(changeset) do
+    Enum.map_join(changeset.errors, ". ", fn {field, {msg, opts}} ->
+      interpolated = Enum.reduce(opts, msg, fn {key, val}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(val))
+      end)
+      "#{Phoenix.Naming.humanize(field)}: #{interpolated}"
+    end)
+  end
+end

--- a/lib/ironiauth_web/controllers/auth_html.ex
+++ b/lib/ironiauth_web/controllers/auth_html.ex
@@ -1,0 +1,5 @@
+defmodule IroniauthWeb.AuthHTML do
+  use IroniauthWeb, :html
+
+  embed_templates "auth_html/*"
+end

--- a/lib/ironiauth_web/controllers/auth_html/forgot_password.html.heex
+++ b/lib/ironiauth_web/controllers/auth_html/forgot_password.html.heex
@@ -1,0 +1,36 @@
+<div class="card">
+  <div class="logo">
+    <h1>Ironiauth</h1>
+    <p>Reset your password</p>
+  </div>
+
+  <%= if @sent do %>
+    <div class="alert-success">
+      If that email exists in <strong><%= @company.name %></strong>, you'll receive reset instructions shortly.
+    </div>
+    <div class="links">
+      <a href={~p"/login?company_uuid=#{@company.uuid}&redirect_uri=#{@redirect_uri}"}>Back to sign in</a>
+    </div>
+  <% else %>
+    <p style="font-size:.875rem;color:#6b7280;margin-bottom:1.25rem;">
+      Enter your email and we'll send you a link to reset your password.
+    </p>
+
+    <form method="post" action={~p"/forgot-password"}>
+      <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+      <input type="hidden" name="company_uuid" value={@company.uuid} />
+      <input type="hidden" name="redirect_uri" value={@redirect_uri} />
+
+      <div class="field">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" required autofocus />
+      </div>
+
+      <button type="submit" class="btn">Send reset instructions</button>
+    </form>
+
+    <div class="links">
+      <a href={~p"/login?company_uuid=#{@company.uuid}&redirect_uri=#{@redirect_uri}"}>Back to sign in</a>
+    </div>
+  <% end %>
+</div>

--- a/lib/ironiauth_web/controllers/auth_html/login.html.heex
+++ b/lib/ironiauth_web/controllers/auth_html/login.html.heex
@@ -1,0 +1,34 @@
+<div class="card">
+  <div class="logo">
+    <h1>Ironiauth</h1>
+    <p>Sign in to <strong><%= @company.name %></strong></p>
+  </div>
+
+  <%= if @error do %>
+    <div class="alert-error"><%= @error %></div>
+  <% end %>
+
+  <form method="post" action={~p"/login"}>
+    <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+    <input type="hidden" name="company_uuid" value={@company.uuid} />
+    <input type="hidden" name="redirect_uri" value={@redirect_uri} />
+
+    <div class="field">
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" value={@email} required autofocus />
+    </div>
+
+    <div class="field">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" required />
+    </div>
+
+    <button type="submit" class="btn">Sign in</button>
+  </form>
+
+  <div class="links">
+    <a href={~p"/forgot-password?company_uuid=#{@company.uuid}&redirect_uri=#{@redirect_uri}"}>Forgot password?</a>
+    <span class="divider">·</span>
+    <a href={~p"/register?company_uuid=#{@company.uuid}&redirect_uri=#{@redirect_uri}"}>Create account</a>
+  </div>
+</div>

--- a/lib/ironiauth_web/controllers/auth_html/register.html.heex
+++ b/lib/ironiauth_web/controllers/auth_html/register.html.heex
@@ -1,0 +1,43 @@
+<div class="card">
+  <div class="logo">
+    <h1>Ironiauth</h1>
+    <p>Create an account for <strong><%= @company.name %></strong></p>
+  </div>
+
+  <%= if @error do %>
+    <div class="alert-error"><%= @error %></div>
+  <% end %>
+
+  <form method="post" action={~p"/register"}>
+    <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+    <input type="hidden" name="company_uuid" value={@company.uuid} />
+    <input type="hidden" name="redirect_uri" value={@redirect_uri} />
+
+    <div class="field">
+      <label for="username">Username</label>
+      <input type="text" id="username" name="user[username]" value={@username} required autofocus />
+    </div>
+
+    <div class="field">
+      <label for="email">Email</label>
+      <input type="email" id="email" name="user[email]" value={@email} required />
+    </div>
+
+    <div class="field">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="user[password]" required />
+    </div>
+
+    <div class="field">
+      <label for="password_confirmation">Confirm password</label>
+      <input type="password" id="password_confirmation" name="user[password_confirmation]" required />
+    </div>
+
+    <button type="submit" class="btn">Create account</button>
+  </form>
+
+  <div class="links">
+    Already have an account?
+    <a href={~p"/login?company_uuid=#{@company.uuid}&redirect_uri=#{@redirect_uri}"}>Sign in</a>
+  </div>
+</div>

--- a/lib/ironiauth_web/controllers/auth_html/reset_password.html.heex
+++ b/lib/ironiauth_web/controllers/auth_html/reset_password.html.heex
@@ -1,0 +1,29 @@
+<div class="card">
+  <div class="logo">
+    <h1>Ironiauth</h1>
+    <p>Set a new password</p>
+  </div>
+
+  <%= if @error do %>
+    <div class="alert-error"><%= @error %></div>
+  <% end %>
+
+  <form method="post" action={~p"/reset-password"}>
+    <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+    <input type="hidden" name="token" value={@token} />
+    <input type="hidden" name="company_uuid" value={@company_uuid} />
+    <input type="hidden" name="redirect_uri" value={@redirect_uri} />
+
+    <div class="field">
+      <label for="password">New password</label>
+      <input type="password" id="password" name="user[password]" required autofocus />
+    </div>
+
+    <div class="field">
+      <label for="password_confirmation">Confirm new password</label>
+      <input type="password" id="password_confirmation" name="user[password_confirmation]" required />
+    </div>
+
+    <button type="submit" class="btn">Reset password</button>
+  </form>
+</div>

--- a/lib/ironiauth_web/controllers/auth_html/reset_password_success.html.heex
+++ b/lib/ironiauth_web/controllers/auth_html/reset_password_success.html.heex
@@ -1,0 +1,11 @@
+<div class="card">
+  <div class="logo">
+    <h1>Ironiauth</h1>
+  </div>
+  <div class="alert-success">
+    Your password has been reset successfully.
+  </div>
+  <div class="links" style="margin-top:1.5rem;">
+    <a href={@login_url} class="btn" style="display:block;text-align:center;color:#fff;text-decoration:none;">Sign in</a>
+  </div>
+</div>

--- a/lib/ironiauth_web/router.ex
+++ b/lib/ironiauth_web/router.ex
@@ -5,6 +5,28 @@ defmodule IroniauthWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :put_root_layout, html: {IroniauthWeb.Layouts, :root}
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
+  # Hosted UI — login/register/forgot-password served por Ironiauth
+  # La app cliente redirige a estas URLs con company_uuid y redirect_uri
+  scope "/", IroniauthWeb do
+    pipe_through :browser
+    get "/login", AuthController, :login
+    post "/login", AuthController, :do_login
+    get "/register", AuthController, :register
+    post "/register", AuthController, :do_register
+    get "/forgot-password", AuthController, :forgot_password
+    post "/forgot-password", AuthController, :do_forgot_password
+    get "/reset-password", AuthController, :reset_password_form
+    post "/reset-password", AuthController, :do_reset_password
+  end
+
   scope "/", IroniauthWeb do
     pipe_through :api
     get "/", RootController, :index
@@ -66,19 +88,8 @@ defmodule IroniauthWeb.Router do
   end
 
 
-  # Catch-all — debe ir al final, después de todas las rutas definidas
-  scope "/", IroniauthWeb do
-    pipe_through :api
-    match :*, "/*path", RootController, :not_found
-  end
-
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:ironiauth, :dev_routes) do
-    # If you want to use the LiveDashboard in production, you should put
-    # it behind authentication and allow only admins to access it.
-    # If your application does not have an admins-only section yet,
-    # you can use Plug.BasicAuth to set up some basic authentication
-    # as long as you are also using SSL (which you should anyway).
     import Phoenix.LiveDashboard.Router
 
     scope "/dev" do
@@ -87,5 +98,11 @@ defmodule IroniauthWeb.Router do
       live_dashboard "/dashboard", metrics: IroniauthWeb.Telemetry
       forward "/mailbox", Plug.Swoosh.MailboxPreview
     end
+  end
+
+  # Catch-all — debe ir al final de todo
+  scope "/", IroniauthWeb do
+    pipe_through :api
+    match :*, "/*path", RootController, :not_found
   end
 end


### PR DESCRIPTION
## Summary

- Ironiauth ahora puede servir los formularios de autenticación directamente (Hosted UI), eliminando la necesidad de que cada app cliente implemente sus propios formularios
- Las apps redirigen el browser a `/login?company_uuid=<uuid>&redirect_uri=<callback>` y Ironiauth devuelve un JWT via redirect
- Flujo completo: login · register · forgot password (email asíncrono) · reset password (sin riesgo de open redirect)

## Cambios principales

- `AuthController` + templates HEEx: login, register, forgot_password, reset_password
- Layout con pipeline `:browser` (CSRF, session, root layout con CSS inline — tema purple centrado)
- `forgot_password_service` pasa `company_uuid` + `redirect_uri` al mailer para que el link de reset preserve el contexto de la company
- Después del reset, redirect a `/login` en Ironiauth (no a la app externa — evita open redirect)
- `User.changeset/2` genera UUID automáticamente (`put_uuid/1`)
- `create_user_for_company/2` fuerza `active: true`
- Rutas dev (`/dev/mailbox`) movidas antes del catch-all (fix: 404 en mailbox)
- `CLAUDE.md` documentado con ambos modos de integración (API-only y Hosted UI)

## Integración con app cliente (Rails open_car)

La app cliente redirige al browser a Ironiauth, recibe el JWT en `/auth/callback` y limpia la URL con `window.location.replace('/')`.

## Test plan

- [ ] `GET /login?company_uuid=<uuid>&redirect_uri=<url>` muestra formulario
- [ ] Login exitoso redirige a `redirect_uri?jwt=<token>`
- [ ] Register exitoso crea usuario con `active: true` y redirige con JWT
- [ ] Forgot password envía email con link que incluye `company_uuid` y `redirect_uri`
- [ ] `/dev/mailbox` muestra el email enviado
- [ ] Reset password: token expirado muestra error, reset exitoso redirige a `/login?company_uuid=...`
- [ ] Rutas no definidas devuelven `{"error": "Not found"}` con 404